### PR TITLE
Remove Cross Account Access from SSM Documents

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -173,6 +173,7 @@ ResourceMap = {
     "aws.sns": "c7n.resources.sns.SNS",
     "aws.sns-subscription": "c7n.resources.sns.SNSSubscription",
     "aws.sqs": "c7n.resources.sqs.SQS",
+    "aws.ssm-document": "c7n.resources.ssm.SSMDocument",
     "aws.ssm-activation": "c7n.resources.ssm.SSMActivation",
     "aws.ssm-managed-instance": "c7n.resources.ssm.ManagedInstance",
     "aws.ssm-parameter": "c7n.resources.ssm.SSMParameter",

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -694,7 +694,6 @@ class RemoveSharingSSMDocument(Action):
                 PermissionType='Share',
                 AccountIdsToRemove=r['c7n:CrossAccountViolations']
             )
-        return resources
 
 
 @SSMDocument.action_registry.register('delete')

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -597,3 +597,17 @@ class PostItem(Action):
 
 
 resources.subscribe(PostItem.register_resource)
+
+
+@resources.register('ssm-document')
+class SSMDocument(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'ssm'
+        enum_spec = ('list_documents', 'DocumentIdentifiers', None)
+        id = 'InstanceId'
+        name = 'Name'
+        date = 'RegistrationDate'
+        arn_type = 'Document'
+
+    permissions = ('ssm:DescribeDocumentPermission','ssm:ListDocuments',)

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -675,17 +675,6 @@ class RemoveSharingSSMDocument(Action):
     schema = type_schema('remove-sharing')
     permissions = ('ssm:ModifyDocumentPermission',)
 
-    def validate(self):
-        found = False
-        for f in self.manager.iter_filters():
-            if isinstance(f, CrossAccountAccessFilter):
-                found = True
-                break
-        if not found:
-            raise PolicyValidationError(
-                "policy:%s action:%s requires cross-account filter" % (
-                    self.manager.ctx.policy.name, self.type))
-
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('ssm')
         for r in resources:

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -626,6 +626,7 @@ class SSMDocumentCrossAccount(CrossAccountAccessFilter):
                 resource: ssm
                 filters:
                   - type: cross-account
+                    whitelist: [xxxxxxxxxxxx]
     """
 
     schema = type_schema('cross-account')
@@ -669,6 +670,9 @@ class SSMDocumentCrossAccount(CrossAccountAccessFilter):
 
 @SSMDocument.action_registry.register('remove-sharing')
 class RemoveSharingSSMDocument(Action):
+    """Remove external accounts from SSM document permissions
+    """
+
     schema = type_schema('remove-sharing')
     permissions = ('ssm:ModifyDocumentPermission',)
 
@@ -696,6 +700,9 @@ class RemoveSharingSSMDocument(Action):
 
 @SSMDocument.action_registry.register('delete')
 class DeleteSSMDocument(Action):
+    """Delete SSM documents
+    """
+
     schema = type_schema('delete')
     permissions = ('ssm:DeleteDocument', 'ssm:ModifyDocumentPermission')
 

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -678,7 +678,7 @@ class RemoveSharingSSMDocument(Action):
     .. code-block:: yaml
 
             policies:
-              - name: ssm-cross-account
+              - name: ssm-remove-sharing
                 resource: ssm-document
                 filters:
                   - type: cross-account
@@ -712,7 +712,7 @@ class DeleteSSMDocument(Action):
     .. code-block:: yaml
 
             policies:
-              - name: ssm-cross-account
+              - name: ssm-delete-documents
                 resource: ssm-document
                 filters:
                   - type: cross-account

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -623,13 +623,12 @@ class SSMDocumentCrossAccount(CrossAccountAccessFilter):
 
             policies:
               - name: ssm-cross-account
-                resource: ssm
+                resource: ssm-document
                 filters:
                   - type: cross-account
                     whitelist: [xxxxxxxxxxxx]
     """
 
-    schema = type_schema('cross-account')
     permissions = ('ssm:DescribeDocumentPermission',)
 
     def process(self, resources, event=None):

--- a/tests/data/placebo/test_get_ssm_documents/ssm.DescribeDocumentPermission_1.json
+++ b/tests/data/placebo/test_get_ssm_documents/ssm.DescribeDocumentPermission_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx",
+            "yyyyyyyyyyyy"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            },
+            {
+                "AccountId": "yyyyyyyyyyyy",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_get_ssm_documents/ssm.DescribeDocumentPermission_2.json
+++ b/tests/data/placebo/test_get_ssm_documents/ssm.DescribeDocumentPermission_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_get_ssm_documents/ssm.ListDocuments_1.json
+++ b/tests/data/placebo/test_get_ssm_documents/ssm.ListDocuments_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "DocumentIdentifiers": [
+            {
+                "Name": "Test-Document-1",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            },
+            {
+                "Name": "Test-Document-2",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_get_ssm_documents/ssm.ListDocuments_1.json
+++ b/tests/data/placebo/test_get_ssm_documents/ssm.ListDocuments_1.json
@@ -29,6 +29,20 @@
                 "SchemaVersion": "2.2",
                 "DocumentFormat": "JSON",
                 "Tags": []
+            },
+            {
+                "Name": "Test-AWS-Document",
+                "Owner": "Amazon",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
             }
         ],
         "ResponseMetadata": {}

--- a/tests/data/placebo/test_ssm_document_add_sharing/ssm.DescribeDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_add_sharing/ssm.DescribeDocumentPermission_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx",
+            "yyyyyyyyyyyy"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            },
+            {
+                "AccountId": "yyyyyyyyyyyy",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_add_sharing/ssm.ListDocuments_1.json
+++ b/tests/data/placebo/test_ssm_document_add_sharing/ssm.ListDocuments_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "DocumentIdentifiers": [
+            {
+                "Name": "Test-Document-1",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            },
+            {
+                "Name": "Test-Document-2",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_add_sharing/ssm.ModifyDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_add_sharing/ssm.ModifyDocumentPermission_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_add_sharing/ssm.ModifyDocumentPermission_2.json
+++ b/tests/data/placebo/test_ssm_document_add_sharing/ssm.ModifyDocumentPermission_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_add_sharing_err/ssm.ListDocuments_1.json
+++ b/tests/data/placebo/test_ssm_document_add_sharing_err/ssm.ListDocuments_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "DocumentIdentifiers": [
+            {
+                "Name": "Test-Document-1",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            },
+            {
+                "Name": "Test-Document-2",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.DeleteDocument_1.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.DeleteDocument_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Message": "Must unshare document first before delete",
+            "Code": "InvalidDocumentOperation"
+        },
+        "ResponseMetadata": {},
+        "Message": "Must unshare document first before delete"
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.DeleteDocument_2.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.DeleteDocument_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_1.json
@@ -3,7 +3,7 @@
     "data": {
         "AccountIds": [
             "xxxxxxxxxxxx",
-            "xxxxxxxxxxxx"
+            "yyyyyyyyyyyy"
         ],
         "AccountSharingInfoList": [
             {
@@ -11,7 +11,7 @@
                 "SharedDocumentVersion": "$DEFAULT"
             },
             {
-                "AccountId": "xxxxxxxxxxxx",
+                "AccountId": "yyyyyyyyyyyy",
                 "SharedDocumentVersion": "$DEFAULT"
             }
         ],

--- a/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx",
+            "xxxxxxxxxxxx"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            },
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_2.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_3.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.DescribeDocumentPermission_3.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx",
+            "xxxxxxxxxxxx"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            },
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.GetDocument_1.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.GetDocument_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Message": "Document with name Test-Document-1 does not exist.",
+            "Code": "InvalidDocument"
+        },
+        "ResponseMetadata": {},
+        "Message": "Document with name Test-Document-1 does not exist."
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.ListDocuments_1.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.ListDocuments_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "DocumentIdentifiers": [
+            {
+                "Name": "Test-Document-1",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            },
+            {
+                "Name": "Test-Document-2",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_delete/ssm.ModifyDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_delete/ssm.ModifyDocumentPermission_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx", 
+            "yyyyyyyyyyyy"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            },
+            {
+                "AccountId": "xxxxxxxxxxxx", 
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_1.json
@@ -2,7 +2,7 @@
     "status_code": 200,
     "data": {
         "AccountIds": [
-            "xxxxxxxxxxxx", 
+            "xxxxxxxxxxxx",
             "yyyyyyyyyyyy"
         ],
         "AccountSharingInfoList": [
@@ -11,7 +11,7 @@
                 "SharedDocumentVersion": "$DEFAULT"
             },
             {
-                "AccountId": "xxxxxxxxxxxx", 
+                "AccountId": "yyyyyyyyyyyy",
                 "SharedDocumentVersion": "$DEFAULT"
             }
         ],

--- a/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_2.json
+++ b/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountIds": [
+            "xxxxxxxxxxxx"
+        ],
+        "AccountSharingInfoList": [
+            {
+                "AccountId": "xxxxxxxxxxxx",
+                "SharedDocumentVersion": "$DEFAULT"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_3.json
+++ b/tests/data/placebo/test_ssm_document_remove_sharing/ssm.DescribeDocumentPermission_3.json
@@ -2,14 +2,9 @@
     "status_code": 200,
     "data": {
         "AccountIds": [
-            "xxxxxxxxxxxx",
             "xxxxxxxxxxxx"
         ],
         "AccountSharingInfoList": [
-            {
-                "AccountId": "xxxxxxxxxxxx",
-                "SharedDocumentVersion": "$DEFAULT"
-            },
             {
                 "AccountId": "xxxxxxxxxxxx",
                 "SharedDocumentVersion": "$DEFAULT"

--- a/tests/data/placebo/test_ssm_document_remove_sharing/ssm.ListDocuments_1.json
+++ b/tests/data/placebo/test_ssm_document_remove_sharing/ssm.ListDocuments_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "DocumentIdentifiers": [
+            {
+                "Name": "Test-Document-1",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            },
+            {
+                "Name": "Test-Document-2",
+                "Owner": "xxxxxxxxxxxx",
+                "PlatformTypes": [
+                    "Windows",
+                    "Linux",
+                    "MacOS"
+                ],
+                "DocumentVersion": "1",
+                "DocumentType": "Command",
+                "SchemaVersion": "2.2",
+                "DocumentFormat": "JSON",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ssm_document_remove_sharing/ssm.ModifyDocumentPermission_1.json
+++ b/tests/data/placebo/test_ssm_document_remove_sharing/ssm.ModifyDocumentPermission_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -301,7 +301,12 @@ class TestSSM(BaseTest):
                         "whitelist": ["xxxxxxxxxxxx"]
                     }
                 ],
-                "actions": [{"type": "remove-sharing"}]
+                "actions": [
+                    {
+                        "type": "set-sharing",
+                        "remove": "matched"
+                    }
+                ]
             },
             session_factory=session_factory,
         )
@@ -312,6 +317,30 @@ class TestSSM(BaseTest):
         )
         self.assertEqual(len(permissions.get('AccountIds')), 1)
         self.assertEqual(permissions.get('AccountIds'), ['xxxxxxxxxxxx'])
+
+    def test_ssm_document_add_sharing(self):
+        session_factory = self.replay_flight_data("test_ssm_document_add_sharing")
+        client = session_factory().client("ssm")
+        p = self.load_policy(
+            {
+                "name": "add-sharing-ssm-documents",
+                "resource": "ssm-document",
+                "actions": [
+                    {
+                        "type": "set-sharing",
+                        "add": ['yyyyyyyyyyyy']
+                    }
+                ]
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+        permissions = client.describe_document_permission(
+            Name='Test-Document-1',
+            PermissionType='Share'
+        )
+        self.assertEqual(len(permissions.get('AccountIds')), 2)
+        self.assertEqual(permissions.get('AccountIds'), ['xxxxxxxxxxxx', 'yyyyyyyyyyyy'])
 
     def test_ssm_document_delete(self):
         session_factory = self.replay_flight_data("test_ssm_document_delete")

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -10,262 +10,278 @@ from .common import BaseTest, functional
 
 class TestOpsCenter(BaseTest):
 
-    def test_post_ops_item(self):
-        factory = self.replay_flight_data('test_post_ops_item')
-        p = self.load_policy({
-            'name': 'checking-lambdas',
-            'description': 'something good',
-            'resource': 'aws.lambda',
-            'source': 'config',
-            'query': [
-                {'clause': "resourceId = 'custodian-aws'"}],
-            'actions': [{
-                'type': 'post-item'}]},
-            session_factory=factory, config={'region': 'us-east-1'})
-        resources = p.run()
-        client = factory().client('ssm', region_name='us-east-1')
-        item = client.get_ops_item(
-            OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
-        arn = p.resource_manager.get_arns(resources)[0]
-        self.assertTrue(
-            arn in item['OperationalData']['/aws/resources']['Value'])
-        self.assertTrue(item['OperationalData']['/aws/dedup'])
-        self.assertEqual(item['Title'], p.name)
-        self.assertEqual(item['Description'], p.data['description'])
+#     def test_post_ops_item(self):
+#         factory = self.replay_flight_data('test_post_ops_item')
+#         p = self.load_policy({
+#             'name': 'checking-lambdas',
+#             'description': 'something good',
+#             'resource': 'aws.lambda',
+#             'source': 'config',
+#             'query': [
+#                 {'clause': "resourceId = 'custodian-aws'"}],
+#             'actions': [{
+#                 'type': 'post-item'}]},
+#             session_factory=factory, config={'region': 'us-east-1'})
+#         resources = p.run()
+#         client = factory().client('ssm', region_name='us-east-1')
+#         item = client.get_ops_item(
+#             OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
+#         arn = p.resource_manager.get_arns(resources)[0]
+#         self.assertTrue(
+#             arn in item['OperationalData']['/aws/resources']['Value'])
+#         self.assertTrue(item['OperationalData']['/aws/dedup'])
+#         self.assertEqual(item['Title'], p.name)
+#         self.assertEqual(item['Description'], p.data['description'])
 
-    def test_ops_item_filter(self):
-        factory = self.replay_flight_data('test_ops_item_filter')
-        p = self.load_policy({
-            'name': 'checking-lambdas',
-            'description': 'something good',
-            'resource': 'aws.lambda',
-            'source': 'config',
-            'query': [
-                {'clause': "resourceId = 'custodian-aws'"}],
-            'filters': [{
-                'type': 'ops-item',
-                'priority': [3, 4, 5],
-                'title': 'checking-lambdas',
-                'source': 'Cloud Custodian',
-            }]},
-            session_factory=factory)
-        resources = p.run()
-        self.assertEqual(len(resources), 1)
-        self.assertEqual(
-            resources[0]['c7n:opsitems'],
-            ['oi-9be57440dcb3'])
+#     def test_ops_item_filter(self):
+#         factory = self.replay_flight_data('test_ops_item_filter')
+#         p = self.load_policy({
+#             'name': 'checking-lambdas',
+#             'description': 'something good',
+#             'resource': 'aws.lambda',
+#             'source': 'config',
+#             'query': [
+#                 {'clause': "resourceId = 'custodian-aws'"}],
+#             'filters': [{
+#                 'type': 'ops-item',
+#                 'priority': [3, 4, 5],
+#                 'title': 'checking-lambdas',
+#                 'source': 'Cloud Custodian',
+#             }]},
+#             session_factory=factory)
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         self.assertEqual(
+#             resources[0]['c7n:opsitems'],
+#             ['oi-9be57440dcb3'])
 
-    def test_post_ops_item_update(self):
-        factory = self.replay_flight_data('test_post_ops_item_update')
-        p = self.load_policy({
-            'name': 'checking-lambdas',
-            'description': 'something good',
-            'resource': 'aws.lambda',
-            'source': 'config',
-            'query': [
-                {'clause': "resourceId = 'custodian-nuke-emr'"}],
-            'actions': [{
-                'type': 'post-item'}]},
-            session_factory=factory)
-        resources = p.run()
-        self.assertEqual(len(resources), 1)
-        client = factory().client('ssm', region_name='us-east-1')
-        item = client.get_ops_item(
-            OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
-        self.assertEqual(
-            json.loads(item['OperationalData']['/aws/resources']['Value']),
-            [{'arn': 'arn:aws:lambda:us-east-1::function:custodian-aws'},
-             {'arn': 'arn:aws:lambda:us-east-1::function:custodian-nuke-emr'}])
+#     def test_post_ops_item_update(self):
+#         factory = self.replay_flight_data('test_post_ops_item_update')
+#         p = self.load_policy({
+#             'name': 'checking-lambdas',
+#             'description': 'something good',
+#             'resource': 'aws.lambda',
+#             'source': 'config',
+#             'query': [
+#                 {'clause': "resourceId = 'custodian-nuke-emr'"}],
+#             'actions': [{
+#                 'type': 'post-item'}]},
+#             session_factory=factory)
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         client = factory().client('ssm', region_name='us-east-1')
+#         item = client.get_ops_item(
+#             OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
+#         self.assertEqual(
+#             json.loads(item['OperationalData']['/aws/resources']['Value']),
+#             [{'arn': 'arn:aws:lambda:us-east-1::function:custodian-aws'},
+#              {'arn': 'arn:aws:lambda:us-east-1::function:custodian-nuke-emr'}])
 
-    def test_update_ops_item(self):
-        factory = self.replay_flight_data('test_update_ops_item')
-        p = self.load_policy({
-            'name': 'checking-lambdas',
-            'description': 'something good',
-            'resource': 'aws.ops-item',
-            'query': [
-                {'Key': 'Status', 'Operator': 'Equal', 'Values': ['Open']}
-            ],
-            'actions': [{
-                'type': 'update',
-                'topics': ['arn:aws:sns:us-west-2:644160558196:aws-command'],
-                'status': 'Resolved',
-            }]},
-            config={'region': 'us-west-2'},
-            session_factory=factory)
-        resources = p.run()
-        self.assertEqual(len(resources), 1)
-        client = factory().client('ssm', region_name='us-west-2')
-        if self.recording:
-            time.sleep(5)
-        item = client.get_ops_item(
-            OpsItemId=resources[0]['OpsItemId'])['OpsItem']
-        self.assertEqual(item['Status'], 'Resolved')
-        self.assertEqual(
-            item['Notifications'],
-            [{'Arn': 'arn:aws:sns:us-west-2:644160558196:aws-command'}])
+#     def test_update_ops_item(self):
+#         factory = self.replay_flight_data('test_update_ops_item')
+#         p = self.load_policy({
+#             'name': 'checking-lambdas',
+#             'description': 'something good',
+#             'resource': 'aws.ops-item',
+#             'query': [
+#                 {'Key': 'Status', 'Operator': 'Equal', 'Values': ['Open']}
+#             ],
+#             'actions': [{
+#                 'type': 'update',
+#                 'topics': ['arn:aws:sns:us-west-2:644160558196:aws-command'],
+#                 'status': 'Resolved',
+#             }]},
+#             config={'region': 'us-west-2'},
+#             session_factory=factory)
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         client = factory().client('ssm', region_name='us-west-2')
+#         if self.recording:
+#             time.sleep(5)
+#         item = client.get_ops_item(
+#             OpsItemId=resources[0]['OpsItemId'])['OpsItem']
+#         self.assertEqual(item['Status'], 'Resolved')
+#         self.assertEqual(
+#             item['Notifications'],
+#             [{'Arn': 'arn:aws:sns:us-west-2:644160558196:aws-command'}])
 
-    def test_invalid_resource_query(self):
-        self.assertRaises(
-            PolicyValidationError, self.load_policy,
-            {'name': 'value',
-             'resource': 'aws.ops-item',
-             'query': [
-                 {'Key': 'Status', 'Operator': 'Equals', 'Values': ['Open']}]},
-            validate=True)
+#     def test_invalid_resource_query(self):
+#         self.assertRaises(
+#             PolicyValidationError, self.load_policy,
+#             {'name': 'value',
+#              'resource': 'aws.ops-item',
+#              'query': [
+#                  {'Key': 'Status', 'Operator': 'Equals', 'Values': ['Open']}]},
+#             validate=True)
 
-    def test_get_resources(self):
-        factory = self.replay_flight_data('test_ops_item_get_resources')
-        p = self.load_policy({
-            'name': 'foo',
-            'resource': 'aws.ops-item'},
-            session_factory=factory,
-            config={'region': 'us-east-1'})
-        resources = p.resource_manager.get_resources('oi-5aa4c36439ed')
-        self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]['OpsItemId'], 'oi-5aa4c36439ed')
+#     def test_get_resources(self):
+#         factory = self.replay_flight_data('test_ops_item_get_resources')
+#         p = self.load_policy({
+#             'name': 'foo',
+#             'resource': 'aws.ops-item'},
+#             session_factory=factory,
+#             config={'region': 'us-east-1'})
+#         resources = p.resource_manager.get_resources('oi-5aa4c36439ed')
+#         self.assertEqual(len(resources), 1)
+#         self.assertEqual(resources[0]['OpsItemId'], 'oi-5aa4c36439ed')
 
 
-class TestSSM(BaseTest):
+# class TestSSM(BaseTest):
 
-    def test_ec2_ssm_send_command_validate(self):
-        self.assertRaises(
-            PolicyValidationError,
-            self.load_policy,
-            {'name': 'ssm-instances',
-             'resource': 'aws.ec2',
-             'actions': [
-                 {'type': 'send-command',
-                  'command': {
-                      'DocumentName': 'AWS-RunShellScript'}}]},
-            validate=True)
+#     def test_ec2_ssm_send_command_validate(self):
+#         self.assertRaises(
+#             PolicyValidationError,
+#             self.load_policy,
+#             {'name': 'ssm-instances',
+#              'resource': 'aws.ec2',
+#              'actions': [
+#                  {'type': 'send-command',
+#                   'command': {
+#                       'DocumentName': 'AWS-RunShellScript'}}]},
+#             validate=True)
 
-    def test_ssm_send_command(self):
-        factory = self.replay_flight_data('test_ssm_send_command')
-        p = self.load_policy({
-            'name': 'ssm-instances',
-            'resource': 'ssm-managed-instance',
-            'filters': [{"PingStatus": "Online"}],
-            'actions': [
-                {'type': 'send-command',
-                 'command': {
-                     'DocumentName': 'AWS-RunShellScript',
-                     'Parameters': {
-                         'commands': [
-                             'wget https://pkg.osquery.io/deb/osquery_3.3.0_1.linux.amd64.deb',
-                             'dpkg -i osquery_3.3.0_1.linux.amd64.deb']}}}]},
-            session_factory=factory, config={'region': 'us-east-2'})
-        resources = p.run()
-        self.assertEqual(len(resources), 1)
-        self.assertTrue('c7n:SendCommand' in resources[0])
+#     def test_ssm_send_command(self):
+#         factory = self.replay_flight_data('test_ssm_send_command')
+#         p = self.load_policy({
+#             'name': 'ssm-instances',
+#             'resource': 'ssm-managed-instance',
+#             'filters': [{"PingStatus": "Online"}],
+#             'actions': [
+#                 {'type': 'send-command',
+#                  'command': {
+#                      'DocumentName': 'AWS-RunShellScript',
+#                      'Parameters': {
+#                          'commands': [
+#                              'wget https://pkg.osquery.io/deb/osquery_3.3.0_1.linux.amd64.deb',
+#                              'dpkg -i osquery_3.3.0_1.linux.amd64.deb']}}}]},
+#             session_factory=factory, config={'region': 'us-east-2'})
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         self.assertTrue('c7n:SendCommand' in resources[0])
 
-        if self.recording:
-            time.sleep(5)
+#         if self.recording:
+#             time.sleep(5)
 
-        result = factory().client('ssm').get_command_invocation(
-            InstanceId=resources[0]['InstanceId'],
-            CommandId=resources[0]['c7n:SendCommand'][0])
-        self.assertEqual(result['Status'], 'Success')
+#         result = factory().client('ssm').get_command_invocation(
+#             InstanceId=resources[0]['InstanceId'],
+#             CommandId=resources[0]['c7n:SendCommand'][0])
+#         self.assertEqual(result['Status'], 'Success')
 
-    def test_ssm_parameter_delete(self):
-        session_factory = self.replay_flight_data("test_ssm_parameter_delete")
-        p = self.load_policy({
-            'name': 'ssm-param-tags',
-            'resource': 'ssm-parameter',
-            'actions': ['delete']},
-            session_factory=session_factory)
-        resources = p.run()
-        self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]['Name'], 'not_secret')
-        client = session_factory().client('ssm')
-        if self.recording:
-            time.sleep(1)
-        self.assertEqual(
-            client.describe_parameters(
-                Filters=[{'Key': 'Name', 'Values': [resources[0]['Name']]}])['Parameters'],
-            [])
+#     def test_ssm_parameter_delete(self):
+#         session_factory = self.replay_flight_data("test_ssm_parameter_delete")
+#         p = self.load_policy({
+#             'name': 'ssm-param-tags',
+#             'resource': 'ssm-parameter',
+#             'actions': ['delete']},
+#             session_factory=session_factory)
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         self.assertEqual(resources[0]['Name'], 'not_secret')
+#         client = session_factory().client('ssm')
+#         if self.recording:
+#             time.sleep(1)
+#         self.assertEqual(
+#             client.describe_parameters(
+#                 Filters=[{'Key': 'Name', 'Values': [resources[0]['Name']]}])['Parameters'],
+#             [])
 
-    def test_ssm_parameter_delete_non_existant(self):
-        session_factory = self.replay_flight_data("test_ssm_parameter_delete_non_existant")
-        p = self.load_policy({
-            'name': 'ssm-param-tags',
-            'resource': 'ssm-parameter',
-            'actions': ['delete']},
-            session_factory=session_factory)
+#     def test_ssm_parameter_delete_non_existant(self):
+#         session_factory = self.replay_flight_data("test_ssm_parameter_delete_non_existant")
+#         p = self.load_policy({
+#             'name': 'ssm-param-tags',
+#             'resource': 'ssm-parameter',
+#             'actions': ['delete']},
+#             session_factory=session_factory)
 
-        # if it raises the test fails
-        p.resource_manager.actions[0].process(
-            [{'Name': 'unicorn'}])
+#         # if it raises the test fails
+#         p.resource_manager.actions[0].process(
+#             [{'Name': 'unicorn'}])
 
-    def test_ssm_parameter_tag_arn(self):
-        session_factory = self.replay_flight_data("test_ssm_parameter_tag_arn")
-        p = self.load_policy({
-            'name': 'ssm-param-tags',
-            'resource': 'ssm-parameter',
-            'filters': [{'tag:Env': 'present'}]},
-            config={'account_id': '123456789123'},
-            session_factory=session_factory)
-        resources = p.resource_manager.get_resources(['/gittersearch/token'])
-        self.assertEqual(len(resources), 1)
-        self.assertEqual(
-            resources[0]['Tags'],
-            [{'Key': 'App', 'Value': 'GitterSearch'},
-             {'Key': 'Env', 'Value': 'Dev'}])
+#     def test_ssm_parameter_tag_arn(self):
+#         session_factory = self.replay_flight_data("test_ssm_parameter_tag_arn")
+#         p = self.load_policy({
+#             'name': 'ssm-param-tags',
+#             'resource': 'ssm-parameter',
+#             'filters': [{'tag:Env': 'present'}]},
+#             config={'account_id': '123456789123'},
+#             session_factory=session_factory)
+#         resources = p.resource_manager.get_resources(['/gittersearch/token'])
+#         self.assertEqual(len(resources), 1)
+#         self.assertEqual(
+#             resources[0]['Tags'],
+#             [{'Key': 'App', 'Value': 'GitterSearch'},
+#              {'Key': 'Env', 'Value': 'Dev'}])
 
-    @functional
-    def test_ssm_parameter_not_secure(self):
-        session_factory = self.replay_flight_data("test_ssm_parameter_not_secure")
-        client = session_factory().client("ssm")
+#     @functional
+#     def test_ssm_parameter_not_secure(self):
+#         session_factory = self.replay_flight_data("test_ssm_parameter_not_secure")
+#         client = session_factory().client("ssm")
 
-        client.put_parameter(Name='test-name',
-                             Type='String',
-                             Overwrite=True,
-                             Value='test-value')
+#         client.put_parameter(Name='test-name',
+#                              Type='String',
+#                              Overwrite=True,
+#                              Value='test-value')
 
-        client.put_parameter(Name='secure-test-name',
-                             Type='SecureString',
-                             Overwrite=True,
-                             Value='secure-test-value')
+#         client.put_parameter(Name='secure-test-name',
+#                              Type='SecureString',
+#                              Overwrite=True,
+#                              Value='secure-test-value')
 
+#         p = self.load_policy(
+#             {
+#                 "name": "ssm-parameter-not-secure",
+#                 "resource": "ssm-parameter",
+#                 "filters": [{"type": "value",
+#                              "op": "ne",
+#                              "key": "Type",
+#                              "value": "SecureString"}]
+#             },
+#             session_factory=session_factory,
+#         )
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         self.addCleanup(client.delete_parameters, Names=['test-name', 'secure-test-name'])
+
+#     def test_ssm_activation_expired(self):
+#         session_factory = self.replay_flight_data("test_ssm_activation_expired")
+#         p = self.load_policy(
+#             {
+#                 "name": "ssm-list-expired-activations",
+#                 "resource": "ssm-activation",
+#                 "filters": [{"type": "value",
+#                              "key": "Expired",
+#                              "value": True}]
+#             },
+#             session_factory=session_factory,
+#         )
+#         resources = p.run()
+#         self.assertEqual(len(resources), 2)
+
+#     def test_ssm_get_manager_instances(self):
+#         session_factory = self.replay_flight_data("test_ssm_get_managed_instances")
+#         p = self.load_policy(
+#             {
+#                 "name": "ssm-get-managed-instances",
+#                 "resource": "ssm-managed-instance"
+#             },
+#             session_factory=session_factory,
+#         )
+#         resources = p.run()
+#         self.assertEqual(len(resources), 1)
+#         self.assertEqual(resources[0]["InstanceId"], "mi-1111aa111aa11a111")
+
+
+    def test_ssm_get_documents(self):
+        session_factory = self.record_flight_data("test_get_ssm_documents")
         p = self.load_policy(
             {
-                "name": "ssm-parameter-not-secure",
-                "resource": "ssm-parameter",
-                "filters": [{"type": "value",
-                             "op": "ne",
-                             "key": "Type",
-                             "value": "SecureString"}]
+                "name": "retrieve-ssm-documents",
+                "resource": "ssm-document",
             },
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertEqual(len(resources), 1)
-        self.addCleanup(client.delete_parameters, Names=['test-name', 'secure-test-name'])
-
-    def test_ssm_activation_expired(self):
-        session_factory = self.replay_flight_data("test_ssm_activation_expired")
-        p = self.load_policy(
-            {
-                "name": "ssm-list-expired-activations",
-                "resource": "ssm-activation",
-                "filters": [{"type": "value",
-                             "key": "Expired",
-                             "value": True}]
-            },
-            session_factory=session_factory,
-        )
-        resources = p.run()
-        self.assertEqual(len(resources), 2)
-
-    def test_ssm_get_manager_instances(self):
-        session_factory = self.replay_flight_data("test_ssm_get_managed_instances")
-        p = self.load_policy(
-            {
-                "name": "ssm-get-managed-instances",
-                "resource": "ssm-managed-instance"
-            },
-            session_factory=session_factory,
-        )
-        resources = p.run()
-        self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]["InstanceId"], "mi-1111aa111aa11a111")
+        print(f'\nResources: ', resources)
+        # self.assertEqual(len(resources), 1)
+        # self.assertEqual(resources[0]["InstanceId"], "mi-1111aa111aa11a111")
+  

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -305,7 +305,7 @@ class TestSSM(BaseTest):
             },
             session_factory=session_factory,
         )
-        resources = p.run()
+        p.run()
         permissions = client.describe_document_permission(
             Name='Test-Document-1',
             PermissionType='Share'
@@ -330,9 +330,9 @@ class TestSSM(BaseTest):
             },
             session_factory=session_factory,
         )
-        resources = p.run()
+        p.run()
         try:
-            document = client.get_document(
+            client.get_document(
                 Name='Test-Document-1',
             )
         except Exception as e:

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -272,6 +272,7 @@ class TestSSM(BaseTest):
 
     def test_get_ssm_documents(self):
         session_factory = self.replay_flight_data("test_get_ssm_documents")
+        client = session_factory().client("ssm")
         p = self.load_policy(
             {
                 "name": "retrieve-ssm-documents",
@@ -290,6 +291,7 @@ class TestSSM(BaseTest):
 
     def test_ssm_document_remove_sharing(self):
         session_factory = self.replay_flight_data("test_ssm_document_remove_sharing")
+        client = session_factory().client("ssm")
         p = self.load_policy(
             {
                 "name": "remove-sharing-ssm-documents",
@@ -309,6 +311,7 @@ class TestSSM(BaseTest):
 
     def test_ssm_document_delete(self):
         session_factory = self.replay_flight_data("test_ssm_document_delete")
+        client = session_factory().client("ssm")
         p = self.load_policy(
             {
                 "name": "delete-ssm-documents",

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -272,7 +272,6 @@ class TestSSM(BaseTest):
 
     def test_get_ssm_documents(self):
         session_factory = self.replay_flight_data("test_get_ssm_documents")
-        client = session_factory().client("ssm")
         p = self.load_policy(
             {
                 "name": "retrieve-ssm-documents",
@@ -291,7 +290,6 @@ class TestSSM(BaseTest):
 
     def test_ssm_document_remove_sharing(self):
         session_factory = self.replay_flight_data("test_ssm_document_remove_sharing")
-        client = session_factory().client("ssm")
         p = self.load_policy(
             {
                 "name": "remove-sharing-ssm-documents",
@@ -311,7 +309,6 @@ class TestSSM(BaseTest):
 
     def test_ssm_document_delete(self):
         session_factory = self.replay_flight_data("test_ssm_document_delete")
-        client = session_factory().client("ssm")
         p = self.load_policy(
             {
                 "name": "delete-ssm-documents",

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -348,7 +348,7 @@ class TestSSM(BaseTest):
         client = session_factory().client("ssm")
         p = self.load_policy(
             {
-                "name": "delete-ssm-documents",
+                "name": "delete-ssm-documents-error",
                 "resource": "ssm-document",
                 "filters": [
                     {

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -326,7 +326,12 @@ class TestSSM(BaseTest):
                         "whitelist": ["xxxxxxxxxxxx"]
                     }
                 ],
-                "actions": [{"type": "delete"}]
+                "actions": [
+                    {
+                        "type": "delete",
+                        "force": True
+                    }
+                ]
             },
             session_factory=session_factory,
         )
@@ -337,3 +342,30 @@ class TestSSM(BaseTest):
             )
         except Exception as e:
             self.assertTrue(e, client.exceptions.InvalidDocument)
+
+    def test_ssm_document_delete_error(self):
+        session_factory = self.replay_flight_data("test_ssm_document_delete")
+        client = session_factory().client("ssm")
+        p = self.load_policy(
+            {
+                "name": "delete-ssm-documents",
+                "resource": "ssm-document",
+                "filters": [
+                    {
+                        "type": "cross-account",
+                        "whitelist": ["xxxxxxxxxxxx"]
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "delete",
+                        "force": False
+                    }
+                ]
+            },
+            session_factory=session_factory,
+        )
+        try:
+            p.run()
+        except Exception as e:
+            self.assertTrue(e, client.exceptions.InvalidDocumentOperation)

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -10,278 +10,318 @@ from .common import BaseTest, functional
 
 class TestOpsCenter(BaseTest):
 
-#     def test_post_ops_item(self):
-#         factory = self.replay_flight_data('test_post_ops_item')
-#         p = self.load_policy({
-#             'name': 'checking-lambdas',
-#             'description': 'something good',
-#             'resource': 'aws.lambda',
-#             'source': 'config',
-#             'query': [
-#                 {'clause': "resourceId = 'custodian-aws'"}],
-#             'actions': [{
-#                 'type': 'post-item'}]},
-#             session_factory=factory, config={'region': 'us-east-1'})
-#         resources = p.run()
-#         client = factory().client('ssm', region_name='us-east-1')
-#         item = client.get_ops_item(
-#             OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
-#         arn = p.resource_manager.get_arns(resources)[0]
-#         self.assertTrue(
-#             arn in item['OperationalData']['/aws/resources']['Value'])
-#         self.assertTrue(item['OperationalData']['/aws/dedup'])
-#         self.assertEqual(item['Title'], p.name)
-#         self.assertEqual(item['Description'], p.data['description'])
+    def test_post_ops_item(self):
+        factory = self.replay_flight_data('test_post_ops_item')
+        p = self.load_policy({
+            'name': 'checking-lambdas',
+            'description': 'something good',
+            'resource': 'aws.lambda',
+            'source': 'config',
+            'query': [
+                {'clause': "resourceId = 'custodian-aws'"}],
+            'actions': [{
+                'type': 'post-item'}]},
+            session_factory=factory, config={'region': 'us-east-1'})
+        resources = p.run()
+        client = factory().client('ssm', region_name='us-east-1')
+        item = client.get_ops_item(
+            OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
+        arn = p.resource_manager.get_arns(resources)[0]
+        self.assertTrue(
+            arn in item['OperationalData']['/aws/resources']['Value'])
+        self.assertTrue(item['OperationalData']['/aws/dedup'])
+        self.assertEqual(item['Title'], p.name)
+        self.assertEqual(item['Description'], p.data['description'])
 
-#     def test_ops_item_filter(self):
-#         factory = self.replay_flight_data('test_ops_item_filter')
-#         p = self.load_policy({
-#             'name': 'checking-lambdas',
-#             'description': 'something good',
-#             'resource': 'aws.lambda',
-#             'source': 'config',
-#             'query': [
-#                 {'clause': "resourceId = 'custodian-aws'"}],
-#             'filters': [{
-#                 'type': 'ops-item',
-#                 'priority': [3, 4, 5],
-#                 'title': 'checking-lambdas',
-#                 'source': 'Cloud Custodian',
-#             }]},
-#             session_factory=factory)
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         self.assertEqual(
-#             resources[0]['c7n:opsitems'],
-#             ['oi-9be57440dcb3'])
+    def test_ops_item_filter(self):
+        factory = self.replay_flight_data('test_ops_item_filter')
+        p = self.load_policy({
+            'name': 'checking-lambdas',
+            'description': 'something good',
+            'resource': 'aws.lambda',
+            'source': 'config',
+            'query': [
+                {'clause': "resourceId = 'custodian-aws'"}],
+            'filters': [{
+                'type': 'ops-item',
+                'priority': [3, 4, 5],
+                'title': 'checking-lambdas',
+                'source': 'Cloud Custodian',
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['c7n:opsitems'],
+            ['oi-9be57440dcb3'])
 
-#     def test_post_ops_item_update(self):
-#         factory = self.replay_flight_data('test_post_ops_item_update')
-#         p = self.load_policy({
-#             'name': 'checking-lambdas',
-#             'description': 'something good',
-#             'resource': 'aws.lambda',
-#             'source': 'config',
-#             'query': [
-#                 {'clause': "resourceId = 'custodian-nuke-emr'"}],
-#             'actions': [{
-#                 'type': 'post-item'}]},
-#             session_factory=factory)
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         client = factory().client('ssm', region_name='us-east-1')
-#         item = client.get_ops_item(
-#             OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
-#         self.assertEqual(
-#             json.loads(item['OperationalData']['/aws/resources']['Value']),
-#             [{'arn': 'arn:aws:lambda:us-east-1::function:custodian-aws'},
-#              {'arn': 'arn:aws:lambda:us-east-1::function:custodian-nuke-emr'}])
+    def test_post_ops_item_update(self):
+        factory = self.replay_flight_data('test_post_ops_item_update')
+        p = self.load_policy({
+            'name': 'checking-lambdas',
+            'description': 'something good',
+            'resource': 'aws.lambda',
+            'source': 'config',
+            'query': [
+                {'clause': "resourceId = 'custodian-nuke-emr'"}],
+            'actions': [{
+                'type': 'post-item'}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = factory().client('ssm', region_name='us-east-1')
+        item = client.get_ops_item(
+            OpsItemId=resources[0]['c7n:opsitem']).get('OpsItem')
+        self.assertEqual(
+            json.loads(item['OperationalData']['/aws/resources']['Value']),
+            [{'arn': 'arn:aws:lambda:us-east-1::function:custodian-aws'},
+             {'arn': 'arn:aws:lambda:us-east-1::function:custodian-nuke-emr'}])
 
-#     def test_update_ops_item(self):
-#         factory = self.replay_flight_data('test_update_ops_item')
-#         p = self.load_policy({
-#             'name': 'checking-lambdas',
-#             'description': 'something good',
-#             'resource': 'aws.ops-item',
-#             'query': [
-#                 {'Key': 'Status', 'Operator': 'Equal', 'Values': ['Open']}
-#             ],
-#             'actions': [{
-#                 'type': 'update',
-#                 'topics': ['arn:aws:sns:us-west-2:644160558196:aws-command'],
-#                 'status': 'Resolved',
-#             }]},
-#             config={'region': 'us-west-2'},
-#             session_factory=factory)
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         client = factory().client('ssm', region_name='us-west-2')
-#         if self.recording:
-#             time.sleep(5)
-#         item = client.get_ops_item(
-#             OpsItemId=resources[0]['OpsItemId'])['OpsItem']
-#         self.assertEqual(item['Status'], 'Resolved')
-#         self.assertEqual(
-#             item['Notifications'],
-#             [{'Arn': 'arn:aws:sns:us-west-2:644160558196:aws-command'}])
+    def test_update_ops_item(self):
+        factory = self.replay_flight_data('test_update_ops_item')
+        p = self.load_policy({
+            'name': 'checking-lambdas',
+            'description': 'something good',
+            'resource': 'aws.ops-item',
+            'query': [
+                {'Key': 'Status', 'Operator': 'Equal', 'Values': ['Open']}
+            ],
+            'actions': [{
+                'type': 'update',
+                'topics': ['arn:aws:sns:us-west-2:644160558196:aws-command'],
+                'status': 'Resolved',
+            }]},
+            config={'region': 'us-west-2'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = factory().client('ssm', region_name='us-west-2')
+        if self.recording:
+            time.sleep(5)
+        item = client.get_ops_item(
+            OpsItemId=resources[0]['OpsItemId'])['OpsItem']
+        self.assertEqual(item['Status'], 'Resolved')
+        self.assertEqual(
+            item['Notifications'],
+            [{'Arn': 'arn:aws:sns:us-west-2:644160558196:aws-command'}])
 
-#     def test_invalid_resource_query(self):
-#         self.assertRaises(
-#             PolicyValidationError, self.load_policy,
-#             {'name': 'value',
-#              'resource': 'aws.ops-item',
-#              'query': [
-#                  {'Key': 'Status', 'Operator': 'Equals', 'Values': ['Open']}]},
-#             validate=True)
+    def test_invalid_resource_query(self):
+        self.assertRaises(
+            PolicyValidationError, self.load_policy,
+            {'name': 'value',
+             'resource': 'aws.ops-item',
+             'query': [
+                 {'Key': 'Status', 'Operator': 'Equals', 'Values': ['Open']}]},
+            validate=True)
 
-#     def test_get_resources(self):
-#         factory = self.replay_flight_data('test_ops_item_get_resources')
-#         p = self.load_policy({
-#             'name': 'foo',
-#             'resource': 'aws.ops-item'},
-#             session_factory=factory,
-#             config={'region': 'us-east-1'})
-#         resources = p.resource_manager.get_resources('oi-5aa4c36439ed')
-#         self.assertEqual(len(resources), 1)
-#         self.assertEqual(resources[0]['OpsItemId'], 'oi-5aa4c36439ed')
-
-
-# class TestSSM(BaseTest):
-
-#     def test_ec2_ssm_send_command_validate(self):
-#         self.assertRaises(
-#             PolicyValidationError,
-#             self.load_policy,
-#             {'name': 'ssm-instances',
-#              'resource': 'aws.ec2',
-#              'actions': [
-#                  {'type': 'send-command',
-#                   'command': {
-#                       'DocumentName': 'AWS-RunShellScript'}}]},
-#             validate=True)
-
-#     def test_ssm_send_command(self):
-#         factory = self.replay_flight_data('test_ssm_send_command')
-#         p = self.load_policy({
-#             'name': 'ssm-instances',
-#             'resource': 'ssm-managed-instance',
-#             'filters': [{"PingStatus": "Online"}],
-#             'actions': [
-#                 {'type': 'send-command',
-#                  'command': {
-#                      'DocumentName': 'AWS-RunShellScript',
-#                      'Parameters': {
-#                          'commands': [
-#                              'wget https://pkg.osquery.io/deb/osquery_3.3.0_1.linux.amd64.deb',
-#                              'dpkg -i osquery_3.3.0_1.linux.amd64.deb']}}}]},
-#             session_factory=factory, config={'region': 'us-east-2'})
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         self.assertTrue('c7n:SendCommand' in resources[0])
-
-#         if self.recording:
-#             time.sleep(5)
-
-#         result = factory().client('ssm').get_command_invocation(
-#             InstanceId=resources[0]['InstanceId'],
-#             CommandId=resources[0]['c7n:SendCommand'][0])
-#         self.assertEqual(result['Status'], 'Success')
-
-#     def test_ssm_parameter_delete(self):
-#         session_factory = self.replay_flight_data("test_ssm_parameter_delete")
-#         p = self.load_policy({
-#             'name': 'ssm-param-tags',
-#             'resource': 'ssm-parameter',
-#             'actions': ['delete']},
-#             session_factory=session_factory)
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         self.assertEqual(resources[0]['Name'], 'not_secret')
-#         client = session_factory().client('ssm')
-#         if self.recording:
-#             time.sleep(1)
-#         self.assertEqual(
-#             client.describe_parameters(
-#                 Filters=[{'Key': 'Name', 'Values': [resources[0]['Name']]}])['Parameters'],
-#             [])
-
-#     def test_ssm_parameter_delete_non_existant(self):
-#         session_factory = self.replay_flight_data("test_ssm_parameter_delete_non_existant")
-#         p = self.load_policy({
-#             'name': 'ssm-param-tags',
-#             'resource': 'ssm-parameter',
-#             'actions': ['delete']},
-#             session_factory=session_factory)
-
-#         # if it raises the test fails
-#         p.resource_manager.actions[0].process(
-#             [{'Name': 'unicorn'}])
-
-#     def test_ssm_parameter_tag_arn(self):
-#         session_factory = self.replay_flight_data("test_ssm_parameter_tag_arn")
-#         p = self.load_policy({
-#             'name': 'ssm-param-tags',
-#             'resource': 'ssm-parameter',
-#             'filters': [{'tag:Env': 'present'}]},
-#             config={'account_id': '123456789123'},
-#             session_factory=session_factory)
-#         resources = p.resource_manager.get_resources(['/gittersearch/token'])
-#         self.assertEqual(len(resources), 1)
-#         self.assertEqual(
-#             resources[0]['Tags'],
-#             [{'Key': 'App', 'Value': 'GitterSearch'},
-#              {'Key': 'Env', 'Value': 'Dev'}])
-
-#     @functional
-#     def test_ssm_parameter_not_secure(self):
-#         session_factory = self.replay_flight_data("test_ssm_parameter_not_secure")
-#         client = session_factory().client("ssm")
-
-#         client.put_parameter(Name='test-name',
-#                              Type='String',
-#                              Overwrite=True,
-#                              Value='test-value')
-
-#         client.put_parameter(Name='secure-test-name',
-#                              Type='SecureString',
-#                              Overwrite=True,
-#                              Value='secure-test-value')
-
-#         p = self.load_policy(
-#             {
-#                 "name": "ssm-parameter-not-secure",
-#                 "resource": "ssm-parameter",
-#                 "filters": [{"type": "value",
-#                              "op": "ne",
-#                              "key": "Type",
-#                              "value": "SecureString"}]
-#             },
-#             session_factory=session_factory,
-#         )
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         self.addCleanup(client.delete_parameters, Names=['test-name', 'secure-test-name'])
-
-#     def test_ssm_activation_expired(self):
-#         session_factory = self.replay_flight_data("test_ssm_activation_expired")
-#         p = self.load_policy(
-#             {
-#                 "name": "ssm-list-expired-activations",
-#                 "resource": "ssm-activation",
-#                 "filters": [{"type": "value",
-#                              "key": "Expired",
-#                              "value": True}]
-#             },
-#             session_factory=session_factory,
-#         )
-#         resources = p.run()
-#         self.assertEqual(len(resources), 2)
-
-#     def test_ssm_get_manager_instances(self):
-#         session_factory = self.replay_flight_data("test_ssm_get_managed_instances")
-#         p = self.load_policy(
-#             {
-#                 "name": "ssm-get-managed-instances",
-#                 "resource": "ssm-managed-instance"
-#             },
-#             session_factory=session_factory,
-#         )
-#         resources = p.run()
-#         self.assertEqual(len(resources), 1)
-#         self.assertEqual(resources[0]["InstanceId"], "mi-1111aa111aa11a111")
+    def test_get_resources(self):
+        factory = self.replay_flight_data('test_ops_item_get_resources')
+        p = self.load_policy({
+            'name': 'foo',
+            'resource': 'aws.ops-item'},
+            session_factory=factory,
+            config={'region': 'us-east-1'})
+        resources = p.resource_manager.get_resources('oi-5aa4c36439ed')
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['OpsItemId'], 'oi-5aa4c36439ed')
 
 
-    def test_ssm_get_documents(self):
-        session_factory = self.record_flight_data("test_get_ssm_documents")
+class TestSSM(BaseTest):
+
+    def test_ec2_ssm_send_command_validate(self):
+        self.assertRaises(
+            PolicyValidationError,
+            self.load_policy,
+            {'name': 'ssm-instances',
+             'resource': 'aws.ec2',
+             'actions': [
+                 {'type': 'send-command',
+                  'command': {
+                      'DocumentName': 'AWS-RunShellScript'}}]},
+            validate=True)
+
+    def test_ssm_send_command(self):
+        factory = self.replay_flight_data('test_ssm_send_command')
+        p = self.load_policy({
+            'name': 'ssm-instances',
+            'resource': 'ssm-managed-instance',
+            'filters': [{"PingStatus": "Online"}],
+            'actions': [
+                {'type': 'send-command',
+                 'command': {
+                     'DocumentName': 'AWS-RunShellScript',
+                     'Parameters': {
+                         'commands': [
+                             'wget https://pkg.osquery.io/deb/osquery_3.3.0_1.linux.amd64.deb',
+                             'dpkg -i osquery_3.3.0_1.linux.amd64.deb']}}}]},
+            session_factory=factory, config={'region': 'us-east-2'})
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertTrue('c7n:SendCommand' in resources[0])
+
+        if self.recording:
+            time.sleep(5)
+
+        result = factory().client('ssm').get_command_invocation(
+            InstanceId=resources[0]['InstanceId'],
+            CommandId=resources[0]['c7n:SendCommand'][0])
+        self.assertEqual(result['Status'], 'Success')
+
+    def test_ssm_parameter_delete(self):
+        session_factory = self.replay_flight_data("test_ssm_parameter_delete")
+        p = self.load_policy({
+            'name': 'ssm-param-tags',
+            'resource': 'ssm-parameter',
+            'actions': ['delete']},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['Name'], 'not_secret')
+        client = session_factory().client('ssm')
+        if self.recording:
+            time.sleep(1)
+        self.assertEqual(
+            client.describe_parameters(
+                Filters=[{'Key': 'Name', 'Values': [resources[0]['Name']]}])['Parameters'],
+            [])
+
+    def test_ssm_parameter_delete_non_existant(self):
+        session_factory = self.replay_flight_data("test_ssm_parameter_delete_non_existant")
+        p = self.load_policy({
+            'name': 'ssm-param-tags',
+            'resource': 'ssm-parameter',
+            'actions': ['delete']},
+            session_factory=session_factory)
+
+        # if it raises the test fails
+        p.resource_manager.actions[0].process(
+            [{'Name': 'unicorn'}])
+
+    def test_ssm_parameter_tag_arn(self):
+        session_factory = self.replay_flight_data("test_ssm_parameter_tag_arn")
+        p = self.load_policy({
+            'name': 'ssm-param-tags',
+            'resource': 'ssm-parameter',
+            'filters': [{'tag:Env': 'present'}]},
+            config={'account_id': '123456789123'},
+            session_factory=session_factory)
+        resources = p.resource_manager.get_resources(['/gittersearch/token'])
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['Tags'],
+            [{'Key': 'App', 'Value': 'GitterSearch'},
+             {'Key': 'Env', 'Value': 'Dev'}])
+
+    @functional
+    def test_ssm_parameter_not_secure(self):
+        session_factory = self.replay_flight_data("test_ssm_parameter_not_secure")
+        client = session_factory().client("ssm")
+
+        client.put_parameter(Name='test-name',
+                             Type='String',
+                             Overwrite=True,
+                             Value='test-value')
+
+        client.put_parameter(Name='secure-test-name',
+                             Type='SecureString',
+                             Overwrite=True,
+                             Value='secure-test-value')
+
         p = self.load_policy(
             {
-                "name": "retrieve-ssm-documents",
-                "resource": "ssm-document",
+                "name": "ssm-parameter-not-secure",
+                "resource": "ssm-parameter",
+                "filters": [{"type": "value",
+                             "op": "ne",
+                             "key": "Type",
+                             "value": "SecureString"}]
             },
             session_factory=session_factory,
         )
         resources = p.run()
-        print(f'\nResources: ', resources)
-        # self.assertEqual(len(resources), 1)
-        # self.assertEqual(resources[0]["InstanceId"], "mi-1111aa111aa11a111")
-  
+        self.assertEqual(len(resources), 1)
+        self.addCleanup(client.delete_parameters, Names=['test-name', 'secure-test-name'])
+
+    def test_ssm_activation_expired(self):
+        session_factory = self.replay_flight_data("test_ssm_activation_expired")
+        p = self.load_policy(
+            {
+                "name": "ssm-list-expired-activations",
+                "resource": "ssm-activation",
+                "filters": [{"type": "value",
+                             "key": "Expired",
+                             "value": True}]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+    def test_ssm_get_manager_instances(self):
+        session_factory = self.replay_flight_data("test_ssm_get_managed_instances")
+        p = self.load_policy(
+            {
+                "name": "ssm-get-managed-instances",
+                "resource": "ssm-managed-instance"
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["InstanceId"], "mi-1111aa111aa11a111")
+
+    def test_get_ssm_documents(self):
+        session_factory = self.replay_flight_data("test_get_ssm_documents")
+        p = self.load_policy(
+            {
+                "name": "retrieve-ssm-documents",
+                "resource": "ssm-document",
+                "filters": [
+                    {
+                        "type": "cross-account",
+                        "whitelist": ["xxxxxxxxxxxx"]
+                    }
+                ]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(resources[0]["c7n:CrossAccountViolations"][0], "yyyyyyyyyyyy")
+
+    def test_ssm_document_remove_sharing(self):
+        session_factory = self.replay_flight_data("test_ssm_document_remove_sharing")
+        p = self.load_policy(
+            {
+                "name": "remove-sharing-ssm-documents",
+                "resource": "ssm-document",
+                "filters": [
+                    {
+                        "type": "cross-account",
+                        "whitelist": ["xxxxxxxxxxxx"]
+                    }
+                ],
+                "actions": [{"type": "remove-sharing"}]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_ssm_document_delete(self):
+        session_factory = self.replay_flight_data("test_ssm_document_delete")
+        p = self.load_policy(
+            {
+                "name": "delete-ssm-documents",
+                "resource": "ssm-document",
+                "filters": [
+                    {
+                        "type": "cross-account",
+                        "whitelist": ["xxxxxxxxxxxx"]
+                    }
+                ],
+                "actions": [{"type": "delete"}]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)


### PR DESCRIPTION
This PR adds SSM Documents as a new resource to Custodian. It also includes the following: 
 - A cross-account filter for SSM docs which finds documents that are shared with non-whitelisted accounts
 - A remove-sharing action which will remove account permissions for external accounts on an SSM document 
 - A delete action to delete SSM documents